### PR TITLE
fix: Error: Session currently disconnected

### DIFF
--- a/src/utils/vc.ts
+++ b/src/utils/vc.ts
@@ -12,6 +12,7 @@ export class VC extends Connector {
 			this.setAccState(accounts);
 		});
 		this.on('disconnect', () => {
+			this.stopBizHeartBeat();  // stop heart beat when disconnected
 			localStorage.removeItem(VCSessionKey);
 		});
 		this.on('session_update', () => {


### PR DESCRIPTION
stop heartbeat when disconnected


When I clicked logout on app(ios/android), the web console would print an error message. Stopping the heartbeat can stop this error message when the link is disconnected.

<img width="901" alt="image" src="https://user-images.githubusercontent.com/40378222/155505198-edb4886a-8cd7-44c3-8679-acc5280d3642.png">

